### PR TITLE
Use full lcmtypes_drake_cc instead of narrower dep

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -32,7 +32,7 @@ cc_binary(
     deps = [
         ":kinova_driver_common",
         "//lcmtypes:lcmtypes_drake_jaco_driver_cc",
-        "@drake//lcmtypes:jaco",
+        "@drake//lcmtypes:lcmtypes_drake_cc",
         "@gflags//:gflags",
         "@jaco_sdk//:usb_command_layer",
         "@lcm",
@@ -49,7 +49,7 @@ cc_binary(
     deps = [
         ":kinova_driver_common_ethernet",
         "//lcmtypes:lcmtypes_drake_jaco_driver_cc",
-        "@drake//lcmtypes:jaco",
+        "@drake//lcmtypes:lcmtypes_drake_cc",
         "@gflags//:gflags",
         "@jaco_sdk//:ethernet_command_layer",
         "@lcm",


### PR DESCRIPTION
The narrower dep is deprecated.
See https://github.com/RobotLocomotion/drake/pull/23467.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sammy-tri/drake-jaco-driver/8)
<!-- Reviewable:end -->
